### PR TITLE
Feature: trust system

### DIFF
--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Admin/AdminConfigModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Admin/AdminConfigModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -77,7 +78,7 @@ namespace MomentumDiscordBot.Discord.Commands.Admin
         [Summary("Gets config option")]
         public async Task GetConfigOptionAsync(string key)
         {
-            var configProperty = Config.GetType().GetProperties().Where(x => x.Name.Contains(key, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            var configProperty = Config.GetType().GetProperties().Where(x => !x.GetCustomAttributes().Any(x => x.GetType() == typeof(HiddenAttribute)) && x.Name.Contains(key, StringComparison.InvariantCultureIgnoreCase)).ToList();
 
             if (!configProperty.Any())
             {

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/GeneralModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/GeneralModule.cs
@@ -16,11 +16,21 @@ namespace MomentumDiscordBot.Discord.Commands
         public Config Config { get; set; }
         [Command("help")]
         [Summary("The command you are running")]
-        public async Task HelpAsync()
+        public async Task HelpAsync(string moduleSearch = null)
         {
             await ReplyAsync("Only the messages you have permission to use in this channel are included.");
             var message = await ReplyNewEmbedAsync("Building the help command... This message will be deleted when all help messages are sent", MomentumColor.Blue);
-            foreach (var module in CommandService.Modules.Where(x => !x.Name.Contains("ModuleBase")))
+
+            var desiredModules = CommandService.Modules.Where(x => !x.Name.Contains("ModuleBase")).ToList();
+
+            if (moduleSearch != null)
+            {
+                desiredModules = desiredModules
+                    .Where(x => x.Name.Equals(moduleSearch, StringComparison.InvariantCultureIgnoreCase) || 
+                                x.Aliases.Contains(moduleSearch, StringComparer.InvariantCultureIgnoreCase)).ToList();
+            }
+
+            foreach (var module in desiredModules)
             {
                 var moduleHelpEmbed = HelpCommandUtilities.GetModuleHelpEmbed(module, Context, Services, Config);
                 if (moduleHelpEmbed.Fields.Length > 0)

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using MomentumDiscordBot.Constants;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Utilities;
+
+namespace MomentumDiscordBot.Discord.Commands.Moderator
+{
+    [Group("trust")]
+    public class ModeratorMediaTrustModule : ModeratorModuleBase
+    {
+        public Config Config { get; set; }
+
+        [Command("status")]
+        public async Task MediaStatusAsync(IGuildUser user)
+        {
+            var embedBuilder = new EmbedBuilder
+            {
+                Title = "Media Trust Status",
+                Author = new EmbedAuthorBuilder()
+                    .WithName(user.Username)
+                    .WithIconUrl(user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl())
+            };
+
+            await using var dbContext = DbContextHelper.GetNewDbContext(Config);
+
+            var messages = await dbContext.DailyMessageCount.ToListAsync();
+            var userMessages = messages.Where(x => x.UserId == user.Id).ToList();
+
+            var oldestMessage = userMessages
+                .OrderBy(x => x.Date)
+                .FirstOrDefault();
+
+            if (oldestMessage == null)
+            {
+                embedBuilder.WithColor(MomentumColor.Red)
+                    .WithDescription("No recorded activity");
+            }
+            else
+            {
+                var totalMessageCount = userMessages.Sum(x => x.MessageCount);
+                var oldestMessageSpan = DateTime.UtcNow - oldestMessage.Date;
+                var hasTrustedRole = user.RoleIds.Any(x => x == Config.MediaVerifiedRoleId);
+                var hasBlacklistedRole = user.RoleIds.Any(x => x == Config.MediaBlacklistedRoleId);
+
+
+                embedBuilder.WithColor(MomentumColor.Blue)
+                    .AddField("Oldest Message Sent", $"{oldestMessageSpan.ToPrettyFormat()} ago")
+                    .AddField("Total Messages", totalMessageCount)
+                    .AddField("Meets Requirements",
+                        oldestMessageSpan.TotalDays > Config.MediaMinimumDays &&
+                        totalMessageCount > Config.MediaMinimumMessages)
+                    .AddField("Has Trusted Role", hasTrustedRole)
+                    .AddField("Has Blacklisted Role", hasBlacklistedRole);
+
+                if (hasBlacklistedRole)
+                {
+                    embedBuilder.Color = MomentumColor.DarkestGray;
+                }
+
+                if (hasTrustedRole)
+                {
+                    embedBuilder.Color = MomentumColor.Green;
+                }
+            }
+
+            await ReplyAsync(embed: embedBuilder.Build());
+        }
+
+        [Command]
+        public async Task TrustUserAsync(IGuildUser user)
+        {
+            var trustedRole = Context.Guild.GetRole(Config.MediaVerifiedRoleId);
+            var blacklistRole = Context.Guild.GetRole(Config.MediaBlacklistedRoleId);
+
+            await user.AddRoleAsync(trustedRole);
+            await user.RemoveRoleAsync(blacklistRole);
+
+            await ReplyNewEmbedAsync("Trusted " + MentionUtils.MentionUser(user.Id), MomentumColor.Blue);
+        }
+
+        [Command("blacklist")]
+        public async Task BlacklistUserAsync(IGuildUser user)
+        {
+            var trustedRole = Context.Guild.GetRole(Config.MediaVerifiedRoleId);
+            var blacklistRole = Context.Guild.GetRole(Config.MediaBlacklistedRoleId);
+
+            await user.RemoveRoleAsync(trustedRole);
+            await user.AddRoleAsync(blacklistRole);
+
+            await ReplyNewEmbedAsync("Blacklisted " + MentionUtils.MentionUser(user.Id), MomentumColor.Blue);
+        }
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
@@ -71,7 +71,7 @@ namespace MomentumDiscordBot.Discord.Commands.Moderator
             await ReplyAsync(embed: embedBuilder.Build());
         }
 
-        [Command]
+        [Command("")]
         [Summary("Manually trusts a user, if applicable, removing the blacklist")]
         public async Task TrustUserAsync(IGuildUser user)
         {

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/Moderator/ModeratorMediaTrustModule.cs
@@ -15,6 +15,7 @@ namespace MomentumDiscordBot.Discord.Commands.Moderator
         public Config Config { get; set; }
 
         [Command("status")]
+        [Summary("Checks to see a user's media trust status")]
         public async Task MediaStatusAsync(IGuildUser user)
         {
             var embedBuilder = new EmbedBuilder
@@ -71,6 +72,7 @@ namespace MomentumDiscordBot.Discord.Commands.Moderator
         }
 
         [Command]
+        [Summary("Manually trusts a user, if applicable, removing the blacklist")]
         public async Task TrustUserAsync(IGuildUser user)
         {
             var trustedRole = Context.Guild.GetRole(Config.MediaVerifiedRoleId);
@@ -83,6 +85,8 @@ namespace MomentumDiscordBot.Discord.Commands.Moderator
         }
 
         [Command("blacklist")]
+        [Summary("Manually blacklist a user, if applicable, removing the trust")]
+
         public async Task BlacklistUserAsync(IGuildUser user)
         {
             var trustedRole = Context.Guild.GetRole(Config.MediaVerifiedRoleId);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -35,5 +35,25 @@ namespace MomentumDiscordBot.Discord.Commands
 
             await ReplyAsync(embed: embedBuilder.Build());
         }
+        [Command("users")]
+        public async Task TopChannelsAsync()
+        {
+            await using var dbContext = DbContextHelper.GetNewDbContext(Config);
+
+            var topUsers = dbContext.DailyMessageCount.ToList().GroupBy(x => x.ChannelId)
+                .Select(x => new KeyValuePair<ulong, long>(x.Key, x.ToList().Sum(x => x.MessageCount)))
+                .OrderByDescending(x => x.Value)
+                .Take(10);
+
+            var embedBuilder = new EmbedBuilder
+            {
+                Title = "Most Active Channels",
+                Description = string.Join(Environment.NewLine,
+                    topUsers.Select(x => MentionUtils.MentionChannel(x.Key) + " - " + x.Value + " messages")),
+                Color = MomentumColor.Blue
+            };
+
+            await ReplyAsync(embed: embedBuilder.Build());
+        }
     }
 }

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -18,38 +18,30 @@ namespace MomentumDiscordBot.Discord.Commands
         [Command("users")]
         public async Task TopUsersAsync()
         {
-            await using var dbContext = DbContextHelper.GetNewDbContext(Config);
-
-            var topUsers = dbContext.DailyMessageCount.ToList().GroupBy(x => x.UserId)
-                .Select(x => new KeyValuePair<ulong, long>(x.Key, x.ToList().Sum(x => x.MessageCount)))
-                .OrderByDescending(x => x.Value)
-                .Take(10);
+            var topUsers = await StatsUtility.GetTopMessages(Config, x => x.UserId);
 
             var embedBuilder = new EmbedBuilder
             {
                 Title = "Most Active Users",
                 Description = string.Join(Environment.NewLine,
-                    topUsers.Select(x => MentionUtils.MentionUser(x.Key) + " - " + x.Value + " messages")),
+                    topUsers.Select(x => MentionUtils.MentionUser(x.Grouping) + " - " + x.MessageCount + " messages")),
                 Color = MomentumColor.Blue
             };
 
             await ReplyAsync(embed: embedBuilder.Build());
         }
+
         [Command("channels")]
         public async Task TopChannelsAsync()
         {
-            await using var dbContext = DbContextHelper.GetNewDbContext(Config);
+            var topUsers = await StatsUtility.GetTopMessages(Config, x => x.ChannelId);
 
-            var topUsers = dbContext.DailyMessageCount.ToList().GroupBy(x => x.ChannelId)
-                .Select(x => new KeyValuePair<ulong, long>(x.Key, x.ToList().Sum(x => x.MessageCount)))
-                .OrderByDescending(x => x.Value)
-                .Take(10);
 
             var embedBuilder = new EmbedBuilder
             {
                 Title = "Most Active Channels",
                 Description = string.Join(Environment.NewLine,
-                    topUsers.Select(x => MentionUtils.MentionChannel(x.Key) + " - " + x.Value + " messages")),
+                    topUsers.Select(x => MentionUtils.MentionChannel(x.Grouping) + " - " + x.MessageCount + " messages")),
                 Color = MomentumColor.Blue
             };
 

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -20,13 +20,9 @@ namespace MomentumDiscordBot.Discord.Commands
         {
             var topUsers = await StatsUtility.GetTopMessages(Config, x => x.UserId);
 
-            var embedBuilder = new EmbedBuilder
-            {
-                Title = "Most Active Users",
-                Description = string.Join(Environment.NewLine,
-                    topUsers.Select(x => MentionUtils.MentionUser(x.Grouping) + " - " + x.MessageCount + " messages")),
-                Color = MomentumColor.Blue
-            };
+            var embedBuilder = topUsers.GetTopStatsEmbedBuilder("Most Active Users",
+                x => $"{MentionUtils.MentionUser(x.Grouping)} - {x.MessageCount} messages");
+
 
             await ReplyAsync(embed: embedBuilder.Build());
         }
@@ -34,16 +30,10 @@ namespace MomentumDiscordBot.Discord.Commands
         [Command("channels")]
         public async Task TopChannelsAsync()
         {
-            var topUsers = await StatsUtility.GetTopMessages(Config, x => x.ChannelId);
+            var topChannels = await StatsUtility.GetTopMessages(Config, x => x.ChannelId);
 
-
-            var embedBuilder = new EmbedBuilder
-            {
-                Title = "Most Active Channels",
-                Description = string.Join(Environment.NewLine,
-                    topUsers.Select(x => MentionUtils.MentionChannel(x.Grouping) + " - " + x.MessageCount + " messages")),
-                Color = MomentumColor.Blue
-            };
+            var embedBuilder = topChannels.GetTopStatsEmbedBuilder("Most Active Channels", 
+                x => $"{MentionUtils.MentionChannel(x.Grouping)} - {x.MessageCount} messages");
 
             await ReplyAsync(embed: embedBuilder.Build());
         }

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using MomentumDiscordBot.Constants;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Utilities;
 
@@ -32,7 +28,7 @@ namespace MomentumDiscordBot.Discord.Commands
         {
             var topChannels = await StatsUtility.GetTopMessages(Config, x => x.ChannelId);
 
-            var embedBuilder = topChannels.GetTopStatsEmbedBuilder("Most Active Channels", 
+            var embedBuilder = topChannels.GetTopStatsEmbedBuilder("Most Active Channels",
                 x => $"{MentionUtils.MentionChannel(x.Grouping)} - {x.MessageCount} messages");
 
             await ReplyAsync(embed: embedBuilder.Build());

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -22,7 +22,8 @@ namespace MomentumDiscordBot.Discord.Commands
 
             var topUsers = dbContext.DailyMessageCount.ToList().GroupBy(x => x.UserId)
                 .Select(x => new KeyValuePair<ulong, long>(x.Key, x.ToList().Sum(x => x.MessageCount)))
-                .OrderByDescending(x => x.Value);
+                .OrderByDescending(x => x.Value)
+                .Take(10);
 
             var embedBuilder = new EmbedBuilder
             {

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -35,7 +35,7 @@ namespace MomentumDiscordBot.Discord.Commands
 
             await ReplyAsync(embed: embedBuilder.Build());
         }
-        [Command("users")]
+        [Command("channels")]
         public async Task TopChannelsAsync()
         {
             await using var dbContext = DbContextHelper.GetNewDbContext(Config);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/Commands/StatsTopModule.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using MomentumDiscordBot.Constants;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Utilities;
+
+namespace MomentumDiscordBot.Discord.Commands
+{
+    [Group("stats top")]
+    public class StatsTopModule : MomentumModuleBase
+    {
+        public Config Config { get; set; }
+
+        [Command("users")]
+        public async Task TopUsersAsync()
+        {
+            await using var dbContext = DbContextHelper.GetNewDbContext(Config);
+
+            var topUsers = dbContext.DailyMessageCount.ToList().GroupBy(x => x.UserId)
+                .Select(x => new KeyValuePair<ulong, long>(x.Key, x.ToList().Sum(x => x.MessageCount)))
+                .OrderByDescending(x => x.Value);
+
+            var embedBuilder = new EmbedBuilder
+            {
+                Title = "Most Active Users",
+                Description = string.Join(Environment.NewLine,
+                    topUsers.Select(x => MentionUtils.MentionUser(x.Key) + " - " + x.Value + " messages")),
+                Color = MomentumColor.Blue
+            };
+
+            await ReplyAsync(embed: embedBuilder.Build());
+        }
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Discord/MomentumBot.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Discord/MomentumBot.cs
@@ -3,8 +3,10 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Models.Data;
 using MomentumDiscordBot.Services;
 using Serilog;
 using Serilog.Events;
@@ -45,7 +47,8 @@ namespace MomentumDiscordBot.Discord
             _ = services.GetRequiredService<MessageHistoryService>();
             _ = services.GetRequiredService<ReactionBasedRoleService>();
             _ = services.GetRequiredService<KeyBeggingService>();
-          
+            _ = services.GetRequiredService<UserTrustService>();
+
             _momentumCommandService =
                 new MomentumCommandService(_discordClient, baseCommandService, _logger, config, services);
 
@@ -64,6 +67,7 @@ namespace MomentumDiscordBot.Discord
                 .AddSingleton<MessageHistoryService>()
                 .AddSingleton<FaqService>()
                 .AddSingleton<KeyBeggingService>()
+                .AddSingleton<UserTrustService>()
                 .BuildServiceProvider();
 
         internal async Task<Exception> RunAsync()

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
@@ -40,6 +40,7 @@ namespace MomentumDiscordBot.Models
         [Hidden]
         [JsonProperty("mysql_connection_string")] public string MySqlConnectionString { get; set; }
 
+        [JsonProperty("media_verified_role")] public ulong MediaVerifiedRoleId { get; set; }
         [JsonIgnore] public Emoji MentionRoleEmoji => new Emoji(MentionRoleEmojiString);
         [JsonIgnore] public Emoji FaqRoleEmoji => new Emoji(FaqRoleEmojiString);
         [JsonIgnore] public Emoji AltAccountEmoji => new Emoji(AltAccountEmojiString);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
@@ -42,6 +42,8 @@ namespace MomentumDiscordBot.Models
 
         [JsonProperty("media_verified_role")] public ulong MediaVerifiedRoleId { get; set; }
         [JsonProperty("media_blacklisted_role")] public ulong MediaBlacklistedRoleId { get; set; }
+        [JsonProperty("media_minimum_days")] public int MediaMinimumDays { get; set; }
+        [JsonProperty("media_minimum_messages")] public int MediaMinimumMessages { get; set; }
         [JsonIgnore] public Emoji MentionRoleEmoji => new Emoji(MentionRoleEmojiString);
         [JsonIgnore] public Emoji FaqRoleEmoji => new Emoji(FaqRoleEmojiString);
         [JsonIgnore] public Emoji AltAccountEmoji => new Emoji(AltAccountEmojiString);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Discord;
 using MomentumDiscordBot.Constants;
+using MomentumDiscordBot.Discord.Commands;
 using Newtonsoft.Json;
 
 namespace MomentumDiscordBot.Models
@@ -36,6 +37,7 @@ namespace MomentumDiscordBot.Models
         [JsonProperty("faq_role")] public ulong FaqRoleId { get; set; }
         [JsonProperty("developer_id")] public ulong DeveloperID { get; set; }
         [JsonProperty("alt_account_emoji")] public string AltAccountEmojiString { get; set; }
+        [Hidden]
         [JsonProperty("mysql_connection_string")] public string MySqlConnectionString { get; set; }
 
         [JsonIgnore] public Emoji MentionRoleEmoji => new Emoji(MentionRoleEmojiString);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
@@ -36,6 +36,8 @@ namespace MomentumDiscordBot.Models
         [JsonProperty("faq_role")] public ulong FaqRoleId { get; set; }
         [JsonProperty("developer_id")] public ulong DeveloperID { get; set; }
         [JsonProperty("alt_account_emoji")] public string AltAccountEmojiString { get; set; }
+        [JsonProperty("mysql_connection_string")] public string MySqlConnectionString { get; set; }
+
         [JsonIgnore] public Emoji MentionRoleEmoji => new Emoji(MentionRoleEmojiString);
         [JsonIgnore] public Emoji FaqRoleEmoji => new Emoji(FaqRoleEmojiString);
         [JsonIgnore] public Emoji AltAccountEmoji => new Emoji(AltAccountEmojiString);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Config.cs
@@ -41,6 +41,7 @@ namespace MomentumDiscordBot.Models
         [JsonProperty("mysql_connection_string")] public string MySqlConnectionString { get; set; }
 
         [JsonProperty("media_verified_role")] public ulong MediaVerifiedRoleId { get; set; }
+        [JsonProperty("media_blacklisted_role")] public ulong MediaBlacklistedRoleId { get; set; }
         [JsonIgnore] public Emoji MentionRoleEmoji => new Emoji(MentionRoleEmojiString);
         [JsonIgnore] public Emoji FaqRoleEmoji => new Emoji(FaqRoleEmojiString);
         [JsonIgnore] public Emoji AltAccountEmoji => new Emoji(AltAccountEmojiString);

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Data/DailyMessageCount.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Data/DailyMessageCount.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Security.AccessControl;
+using System.Text;
+
+namespace MomentumDiscordBot.Models.Data
+{
+    [Table("message_count")]
+    public class DailyMessageCount
+    {
+        [Required]
+        [Column(TypeName = "BIGINT UNSIGNED NOT NULL")]
+        public ulong UserId { get; set; }
+        [Required]
+
+        [Column(TypeName = "BIGINT UNSIGNED NOT NULL")]
+        public ulong ChannelId { get; set; }
+        [Required]
+
+        [Column(TypeName = "DATE NOT NULL")]
+        public DateTime Date { get; set; }
+        [Column(TypeName = "MEDIUMINT UNSIGNED")]
+        public uint MessageCount { get; set; }
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Models/Data/MomentumDiscordDbContext.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Models/Data/MomentumDiscordDbContext.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace MomentumDiscordBot.Models.Data
+{
+    public class MomentumDiscordDbContext : DbContext
+    {
+        public MomentumDiscordDbContext(DbContextOptions<MomentumDiscordDbContext> options) : base(options)
+        {
+
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DailyMessageCount>()
+                .HasKey(x => new {x.UserId, x.ChannelId, x.Date});
+        }
+
+        public DbSet<DailyMessageCount> DailyMessageCount { get; set; }
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/MomentumDiscordBot.csproj
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/MomentumDiscordBot.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Discord.Net" Version="2.3.0-dev-20200618.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.2" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />

--- a/src/MomentumDiscordBot/MomentumDiscordBot/MomentumDiscordBot.csproj
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/MomentumDiscordBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="2.3.0-dev-20200618.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
@@ -49,7 +49,7 @@ namespace MomentumDiscordBot.Services
             var user = dbContext.DailyMessageCount
                 .SingleOrDefault(x => x.UserId == message.Author.Id &&
                                       x.ChannelId == message.Channel.Id &&
-                                      x.Date == DateTime.UtcNow.Date);
+                                      x.Date == message.CreatedAt.UtcDateTime.Date);
 
             if (user != null)
             {
@@ -62,7 +62,7 @@ namespace MomentumDiscordBot.Services
                 var newUser = new DailyMessageCount
                 {
                     ChannelId = message.Channel.Id,
-                    Date = DateTime.UtcNow.Date,
+                    Date = message.CreatedAt.UtcDateTime.Date,
                     UserId = message.Author.Id,
                     MessageCount = 1
                 };

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
@@ -9,6 +9,7 @@ using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Models.Data;
+using MomentumDiscordBot.Utilities;
 using Serilog;
 
 namespace MomentumDiscordBot.Services
@@ -37,9 +38,7 @@ namespace MomentumDiscordBot.Services
 
             _ = Task.Run(async () =>
             {
-                await using var dbContext = new MomentumDiscordDbContext(new DbContextOptionsBuilder<MomentumDiscordDbContext>().UseMySql(_config.MySqlConnectionString).Options);
-                LogMessageCount(dbContext, message);
-                await CheckVerifiedRoleAsync(dbContext, message);
+                await using var dbContext = DbContextHelper.GetNewDbContext(_config);
             });
 
             return Task.CompletedTask;

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
@@ -30,8 +30,8 @@ namespace MomentumDiscordBot.Services
 
         private Task MessageReceived(SocketMessage message)
         {
-            // Ignore bots
-            if (message.Author.IsBot)
+            // Ignore bots or DMs 
+            if (message.Author.IsBot || message.Channel is IDMChannel)
             {
                 return Task.CompletedTask;
             }

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Models.Data;
+using Serilog;
+
+namespace MomentumDiscordBot.Services
+{
+    public class UserTrustService
+    {
+        private ILogger _logger;
+        private DiscordSocketClient _discordClient;
+        private Config _config;
+        public UserTrustService(ILogger logger, DiscordSocketClient discordClient, Config config)
+        {
+            _logger = logger;
+            _discordClient = discordClient;
+            _config = config;
+
+            _discordClient.MessageReceived += MessageReceived;
+        }
+
+        private Task MessageReceived(SocketMessage message)
+        {
+            // Ignore bots
+            if (message.Author.IsBot)
+            {
+                return Task.CompletedTask;
+            }
+
+            _ = Task.Run(() =>
+            {
+                using var dbContext = new MomentumDiscordDbContext(new DbContextOptionsBuilder<MomentumDiscordDbContext>().UseMySql(_config.MySqlConnectionString).Options);
+                LogMessageCount(dbContext, message);
+            });
+
+            return Task.CompletedTask;
+        }
+
+        private void LogMessageCount(MomentumDiscordDbContext dbContext, SocketMessage message)
+        {
+            var users = dbContext.DailyMessageCount.ToList();
+            var user = dbContext.DailyMessageCount
+                .SingleOrDefault(x => x.UserId == message.Author.Id &&
+                                      x.ChannelId == message.Channel.Id &&
+                                      x.Date == DateTime.UtcNow.Date);
+
+            if (user != null)
+            {
+                // If they have a message count for that day, just increment
+                user.MessageCount++;
+            }
+            else
+            {
+                // No data for the current state, make a new message count
+                var newUser = new DailyMessageCount
+                {
+                    ChannelId = message.Channel.Id,
+                    Date = DateTime.UtcNow.Date,
+                    UserId = message.Author.Id,
+                    MessageCount = 1
+                };
+
+                dbContext.Add(newUser);
+            }
+
+            dbContext.SaveChanges();
+        }
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Services/UserTrustService.cs
@@ -39,6 +39,8 @@ namespace MomentumDiscordBot.Services
             _ = Task.Run(async () =>
             {
                 await using var dbContext = DbContextHelper.GetNewDbContext(_config);
+                LogMessageCount(dbContext, message);
+                await CheckVerifiedRoleAsync(dbContext, message);
             });
 
             return Task.CompletedTask;

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/DbContextHelper.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/DbContextHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Models.Data;
+
+namespace MomentumDiscordBot.Utilities
+{
+    public static class DbContextHelper
+    {
+        public static MomentumDiscordDbContext GetNewDbContext(Config config) =>
+            new MomentumDiscordDbContext(new DbContextOptionsBuilder<MomentumDiscordDbContext>()
+                .UseMySql(config.MySqlConnectionString).Options);
+    }
+}

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using MomentumDiscordBot.Constants;
@@ -13,18 +11,20 @@ namespace MomentumDiscordBot.Utilities
 {
     public static class StatsUtility
     {
-        public static async Task<List<(T Grouping, long MessageCount)>> GetTopMessages<T>(Config config, Func<DailyMessageCount, T> groupFunc)
+        public static async Task<List<(T Grouping, long MessageCount)>> GetTopMessages<T>(Config config,
+            Func<DailyMessageCount, T> groupFunc)
         {
             await using var dbContext = DbContextHelper.GetNewDbContext(config);
 
             return dbContext.DailyMessageCount.ToList().GroupBy(groupFunc)
-                .Select(x => (Grouping:x.Key, MessageCount:x.ToList().Sum(x => x.MessageCount)))
+                .Select(x => (Grouping: x.Key, MessageCount: x.ToList().Sum(x => x.MessageCount)))
                 .OrderByDescending(x => x.MessageCount)
                 .Take(10)
                 .ToList();
         }
 
-        public static EmbedBuilder GetTopStatsEmbedBuilder<T>(this List<(T Grouping, long MessageCount)> topStats, string title,
+        public static EmbedBuilder GetTopStatsEmbedBuilder<T>(this List<(T Grouping, long MessageCount)> topStats,
+            string title,
             Func<(T Grouping, long MessageCount), string> elementStringConverterFunc) =>
             new EmbedBuilder
             {

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using Discord;
+using MomentumDiscordBot.Constants;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Models.Data;
 
@@ -20,5 +23,15 @@ namespace MomentumDiscordBot.Utilities
                 .Take(10)
                 .ToList();
         }
+
+        public static EmbedBuilder GetTopStatsEmbedBuilder<T>(this List<(T Grouping, long MessageCount)> topStats, string title,
+            Func<(T Grouping, long MessageCount), string> elementStringConverterFunc) =>
+            new EmbedBuilder
+            {
+                Title = title,
+                Description = string.Join(Environment.NewLine,
+                    topStats.Select(elementStringConverterFunc)),
+                Color = MomentumColor.Blue
+            };
     }
 }

--- a/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
+++ b/src/MomentumDiscordBot/MomentumDiscordBot/Utilities/StatsUtility.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Models.Data;
+
+namespace MomentumDiscordBot.Utilities
+{
+    public static class StatsUtility
+    {
+        public static async Task<List<(T Grouping, long MessageCount)>> GetTopMessages<T>(Config config, Func<DailyMessageCount, T> groupFunc)
+        {
+            await using var dbContext = DbContextHelper.GetNewDbContext(config);
+
+            return dbContext.DailyMessageCount.ToList().GroupBy(groupFunc)
+                .Select(x => (Grouping:x.Key, MessageCount:x.ToList().Sum(x => x.MessageCount)))
+                .OrderByDescending(x => x.MessageCount)
+                .Take(10)
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
Closes #78 

Bit of a big PR:

- Allows for admin config properties to be set only
- Allows for using help command with a module/alias search string
- For each day, each channel and each user, log how many messages are sent
- Once a user meets the minimum requirements (and no blacklist) trust them.
- Added !stats top users/channels to see some info
- Added !trust commands to help with the trust system