### PR TITLE
fix: Use "UserLogin" for building Twitch embed URLs

### DIFF
--- a/MomentumDiscordBot/MomentumDiscordBot.csproj
+++ b/MomentumDiscordBot/MomentumDiscordBot.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
-    <PackageReference Include="TwitchLib.Api" Version="3.1.3" />
+    <PackageReference Include="TwitchLib.Api" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/MomentumDiscordBot/Services/StreamMonitorService.cs
+++ b/MomentumDiscordBot/Services/StreamMonitorService.cs
@@ -211,11 +211,11 @@ namespace MomentumDiscordBot.Services
                     {
                         Name = stream.UserName,
                         IconUrl = await TwitchApiService.GetStreamerIconUrlAsync(stream.UserId),
-                        Url = $"https://twitch.tv/{stream.UserName}"
+                        Url = $"https://twitch.tv/{stream.UserLogin}"
                     },
                     ImageUrl = stream.ThumbnailUrl.Replace("{width}", "1280").Replace("{height}", "720") + "?q=" +
                                Environment.TickCount,
-                    Url = $"https://twitch.tv/{stream.UserName}",
+                    Url = $"https://twitch.tv/{stream.UserLogin}",
                     Timestamp = DateTimeOffset.Now
                 }.AddField("🔴 Viewers", stream.ViewerCount.ToString(), true)
                 .AddField("🎦 Uptime", (DateTime.UtcNow - stream.StartedAt).ToPrettyFormat(2), true)

--- a/MomentumDiscordBot/Services/StreamMonitorService.cs
+++ b/MomentumDiscordBot/Services/StreamMonitorService.cs
@@ -9,7 +9,7 @@ using DSharpPlus.EventArgs;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Utilities;
 using Serilog;
-using TwitchLib.Api.Helix.Models.Streams;
+using TwitchLib.Api.Helix.Models.Streams.GetStreams;
 
 namespace MomentumDiscordBot.Services
 {

--- a/MomentumDiscordBot/Services/TwitchApiService.cs
+++ b/MomentumDiscordBot/Services/TwitchApiService.cs
@@ -7,6 +7,7 @@ using MomentumDiscordBot.Models;
 using Serilog;
 using TwitchLib.Api;
 using TwitchLib.Api.Helix.Models.Streams;
+using TwitchLib.Api.Helix.Models.Streams.GetStreams;
 
 namespace MomentumDiscordBot.Services
 {


### PR DESCRIPTION
Those with Display Names (e.g. in Korean, Chinese, etc) vs their actual login account names can lead to having the URL lead to a non-existent page

Recent example was:
![image](https://user-images.githubusercontent.com/5162166/113082561-b6a91680-91a8-11eb-8937-338d4a1658b0.png)

Linking to: `https://twitch.tv/%EA%B5%90%EB%8F%99%EA%B0%9C%EC%9E%A5%EC%88%98`
When it should be linking to: `https://www.twitch.tv/skten2001`