### PR TITLE
Only register Seq sink if seq_address is set

### DIFF
--- a/MomentumDiscordBot/Program.cs
+++ b/MomentumDiscordBot/Program.cs
@@ -18,10 +18,17 @@ namespace MomentumDiscordBot
 
             SelfLog.Enable(Console.WriteLine);
 
-            using var logger = new LoggerConfiguration()
+            var loggerConfig = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.Console()
-                .WriteTo.Seq(config.SeqAddress, LogEventLevel.Information, apiKey: config.SeqToken)
+                .WriteTo.Console();
+
+            if (!string.IsNullOrEmpty(config.SeqAddress))
+            {
+                loggerConfig
+                    .WriteTo.Seq(config.SeqAddress, LogEventLevel.Information, apiKey: config.SeqToken);
+            }
+
+            using var logger = loggerConfig
                 .Enrich.WithProperty("Environment", config.Environment)
                 .Enrich.WithProperty("Application", "Discord Bot")
                 .CreateLogger();


### PR DESCRIPTION
Fixes the current shit breaking the bot. Don't care that much about Seq anyway, we can set up our own instance if needed but it shouldn't be required for the bot to function.