### PR TITLE
forcerestart message

### DIFF
--- a/MomentumDiscordBot/Commands/Admin/AdminModule.cs
+++ b/MomentumDiscordBot/Commands/Admin/AdminModule.cs
@@ -13,9 +13,11 @@ namespace MomentumDiscordBot.Commands.Admin
         [SlashCommand("forcereconnect", "Simulates the Discord API requesting a reconnect")]
         public async Task ForceReconnectAsync(InteractionContext context, [Option("seconds", "seconds")] long seconds)
         {
+            await context.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
             await DiscordClient.DisconnectAsync();
             await Task.Delay((int)(seconds * 1000));
-            await DiscordClient.ReconnectAsync();
+            await DiscordClient.ConnectAsync();
+            await context.EditResponseAsync(new DiscordWebhookBuilder().WithContent("Reconnected!"));
         }
         
         public const string ForcerestartCommandName = "forcerestart";

--- a/MomentumDiscordBot/Commands/Admin/AdminModule.cs
+++ b/MomentumDiscordBot/Commands/Admin/AdminModule.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.SlashCommands;
+using DSharpPlus.Entities;
 
 namespace MomentumDiscordBot.Commands.Admin
 {
@@ -17,13 +18,22 @@ namespace MomentumDiscordBot.Commands.Admin
             await DiscordClient.ReconnectAsync();
         }
         
-        [SlashCommand("forcerestart", "Forces the bot to exit the process, and have Docker auto-restart it")]
+        public const string ForcerestartCommandName = "forcerestart";
+        [SlashCommand(ForcerestartCommandName, "Forces the bot to exit the process, and have Docker auto-restart it")]
         public Task ForceRestartAsync(InteractionContext context)
         {
             Logger.Warning("{User} forced the bot to restart", context.User);
             
-            // Safe exit
-            Environment.Exit(0);
+            _ = Task.Run(async () =>
+            {
+                await ReplyNewEmbedAsync(context, "Restarting ...", DiscordColor.Orange);
+            });
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(5 * 1000);
+                // Safe exit
+                Environment.Exit(0);
+            });
 
             return Task.CompletedTask;
         }

--- a/MomentumDiscordBot/Services/SlashCommandService.cs
+++ b/MomentumDiscordBot/Services/SlashCommandService.cs
@@ -5,16 +5,21 @@ using DSharpPlus;
 using DSharpPlus.SlashCommands;
 using DSharpPlus.SlashCommands.EventArgs;
 using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
 using Microsoft.Extensions.Logging;
 using MomentumDiscordBot.Constants;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Utilities;
+using MomentumDiscordBot.Commands.Admin;
 
 namespace MomentumDiscordBot.Services
 {
     [Microservice(MicroserviceType.InjectAndInitialize)]
     public class SlashCommandService
     {
+        private readonly Configuration _config;
+        private readonly DiscordClient _discordClient;
+        private DiscordChannel _textChannel;
         public SlashCommandService(Configuration config, DiscordClient discordClient, IServiceProvider services)
         {
             var commands = discordClient.UseSlashCommands(new SlashCommandsConfiguration
@@ -22,9 +27,14 @@ namespace MomentumDiscordBot.Services
                 Services = services
             });
 
+
+            _config = config;
+            _discordClient = discordClient;
+
             commands.RegisterCommands(Assembly.GetEntryAssembly());
 
             commands.SlashCommandErrored += _commands_SlashCommandErrored;
+            discordClient.GuildDownloadCompleted += _discordClient_GuildsDownloaded;
         }
 
         private Task _commands_SlashCommandErrored(SlashCommandsExtension sender, SlashCommandErrorEventArgs e)
@@ -51,6 +61,60 @@ namespace MomentumDiscordBot.Services
             });
 
             return Task.CompletedTask;
+        }
+
+        private Task _discordClient_GuildsDownloaded(DiscordClient sender, GuildDownloadCompletedEventArgs e)
+        {
+
+            _ = Task.Run(async () =>
+            {
+                _textChannel = await _discordClient.GetChannelAsync(_config.AdminBotChannel);
+                await FindRestartMessageAsync();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        private async Task FindRestartMessageAsync()
+        {
+            // Filter only messages from this bot
+            var existingMessages = (await _textChannel.GetMessagesAsync(50)).FromSelf(_discordClient);
+
+            foreach (var message in existingMessages)
+            {
+                var (result, restartMessage) = await TryFindRestartMessageAsync(message);
+                if (!result) continue;
+                // restart message found
+                if(restartMessage != null)
+                {
+                    // restartMessage is null when we already responded
+
+                    var diff = DateTimeOffset.Now - restartMessage.Timestamp;
+                    var embed = new DiscordEmbedBuilder
+                    {
+                        Description = $"Restart complete! Took {diff.TotalSeconds:N2} seconds.",
+                        Color = MomentumColor.Blue
+                    };
+                    await restartMessage.RespondAsync(embed: embed);
+                }
+                break;
+            }
+        }
+
+        private async Task<(bool result, DiscordMessage restartMessage)> TryFindRestartMessageAsync(DiscordMessage input)
+        {
+            var message = await input.Channel.GetMessageAsync(input.Id);
+
+            bool isReply = false;
+            if (message.ReferencedMessage != null)
+            {
+                message = message.ReferencedMessage;
+                isReply = true;
+            }
+            if (message.Interaction is not { Name: AdminModule.ForcerestartCommandName }) return (false, null);
+
+            return (true, isReply ? null : input);
+
         }
     }
 }


### PR DESCRIPTION
Added a message to the forcerestart command and after the restart
Stole some of the "after restart" from ReactionBasedRoleService. Hope this doesn't get called too often.
Exit is in its own task because I didn't want to wait for the reply before exiting. What if the ReplyAsync never returns. Not sure if this can actually happen.