### PR TITLE
Custom commands

### DIFF
--- a/MomentumDiscordBot/Commands/Admin/AdminModule.cs
+++ b/MomentumDiscordBot/Commands/Admin/AdminModule.cs
@@ -19,13 +19,13 @@ namespace MomentumDiscordBot.Commands.Admin
             await DiscordClient.ConnectAsync();
             await context.EditResponseAsync(new DiscordWebhookBuilder().WithContent("Reconnected!"));
         }
-        
+
         public const string ForcerestartCommandName = "forcerestart";
         [SlashCommand(ForcerestartCommandName, "Forces the bot to exit the process, and have Docker auto-restart it")]
         public Task ForceRestartAsync(InteractionContext context)
         {
             Logger.Warning("{User} forced the bot to restart", context.User);
-            
+
             _ = Task.Run(async () =>
             {
                 await ReplyNewEmbedAsync(context, "Restarting ...", DiscordColor.Orange);

--- a/MomentumDiscordBot/Commands/Autocomplete/CustomCommandAutoCompleteProvider.cs
+++ b/MomentumDiscordBot/Commands/Autocomplete/CustomCommandAutoCompleteProvider.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using DSharpPlus.Entities;
+using MomentumDiscordBot.Models;
+using DSharpPlus.SlashCommands;
+
+namespace MomentumDiscordBot.Commands.Autocomplete
+{
+    public class AutoCompleteProvider : IAutocompleteProvider
+    {
+        private IEnumerable<string> findCommand(IEnumerable<string> commands, string s)
+        {
+            return commands.Where(x => x.Contains(s)).Take(25).OrderBy(x => x);
+        }
+        public Task<IEnumerable<DiscordAutoCompleteChoice>> Provider(AutocompleteContext context)
+        {
+            var commands = context.Services.GetRequiredService<Configuration>().CustomCommands.Keys;
+            var choices = findCommand(commands, context.OptionValue.ToString());
+            if (!choices.Any())
+            {
+                DiscordEmoji emoji;
+                if (DiscordEmoji.TryFromName(context.Client, context.OptionValue.ToString(), out emoji))
+                {
+                    choices = findCommand(commands, emoji.ToString());
+                }
+            }
+            return Task.FromResult(choices.Select(command => new DiscordAutoCompleteChoice(command, command)));
+        }
+    }
+}

--- a/MomentumDiscordBot/Commands/Checks/DescriptiveCheckBaseAttribute.cs
+++ b/MomentumDiscordBot/Commands/Checks/DescriptiveCheckBaseAttribute.cs
@@ -6,4 +6,8 @@ namespace MomentumDiscordBot.Commands.Checks
     {
         public string FailureResponse { get; set; }
     }
+    public abstract class ContextMenuDescriptiveCheckBaseAttribute :  ContextMenuCheckBaseAttribute
+    {
+        public string FailureResponse { get; set; }
+    }
 }

--- a/MomentumDiscordBot/Commands/Checks/RequireUserModeratorRoleAttribute.cs
+++ b/MomentumDiscordBot/Commands/Checks/RequireUserModeratorRoleAttribute.cs
@@ -8,4 +8,12 @@
             FailureResponse = "Missing the Moderator role";
         }
     }
+    public class ContextMenuRequireUserModeratorRoleAttribute : ContextMenuRequireUserRoleAttribute
+    {
+        public ContextMenuRequireUserModeratorRoleAttribute()
+        {
+            RoleIdSelector = configuration => configuration.ModeratorRoleID;
+            FailureResponse = "Missing the Moderator role";
+        }
+    }
 }

--- a/MomentumDiscordBot/Commands/Checks/RequireUserRoleAttribute.cs
+++ b/MomentumDiscordBot/Commands/Checks/RequireUserRoleAttribute.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.SlashCommands;
-using DSharpPlus.Entities;
 using Microsoft.Extensions.DependencyInjection;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Utilities;

--- a/MomentumDiscordBot/Commands/Checks/RequireUserRoleAttribute.cs
+++ b/MomentumDiscordBot/Commands/Checks/RequireUserRoleAttribute.cs
@@ -5,6 +5,7 @@ using DSharpPlus.SlashCommands;
 using DSharpPlus.Entities;
 using Microsoft.Extensions.DependencyInjection;
 using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Utilities;
 
 namespace MomentumDiscordBot.Commands.Checks
 {
@@ -15,18 +16,17 @@ namespace MomentumDiscordBot.Commands.Checks
         public override Task<bool> ExecuteChecksAsync(InteractionContext context)
         {
             var config = context.Services.GetRequiredService<Configuration>();
-            return Task.FromResult(RequireRole(context.User, RoleIdSelector(config)));
+            return Task.FromResult(context.User.RequireRole(RoleIdSelector(config)));
         }
+    }
+    public abstract class ContextMenuRequireUserRoleAttribute : ContextMenuDescriptiveCheckBaseAttribute
+    {
+        protected Func<Configuration, ulong> RoleIdSelector;
 
-        private static bool RequireRole(DiscordUser user, ulong roleId)
+        public override Task<bool> ExecuteChecksAsync(ContextMenuContext context)
         {
-            // Check if this user is a Guild User, which is the only context where roles exist
-            if (!(user is DiscordMember member))
-            {
-                return false;
-            }
-
-            return member.Roles.Any(role => role.Id == roleId);
+            var config = context.Services.GetRequiredService<Configuration>();
+            return Task.FromResult(context.User.RequireRole(RoleIdSelector(config)));
         }
     }
 }

--- a/MomentumDiscordBot/Commands/Checks/RequireUserTrustedRoleAttribute.cs
+++ b/MomentumDiscordBot/Commands/Checks/RequireUserTrustedRoleAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace MomentumDiscordBot.Commands.Checks
+{
+    public class RequireUserTrustedRoleAttribute : RequireUserRoleAttribute
+    {
+        public RequireUserTrustedRoleAttribute()
+        {
+            RoleIdSelector = configuration => configuration.MediaVerifiedRoleId;
+            FailureResponse = "Missing the Trusted role";
+        }
+    }
+}

--- a/MomentumDiscordBot/Commands/General/GeneralModule.cs
+++ b/MomentumDiscordBot/Commands/General/GeneralModule.cs
@@ -1,9 +1,36 @@
-﻿using MomentumDiscordBot.Models;
+﻿using System.Threading.Tasks;
+using DSharpPlus.SlashCommands;
+using DSharpPlus.Entities;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Constants;
+using MomentumDiscordBot.Commands.Checks;
+using MomentumDiscordBot.Commands.Autocomplete;
 
 namespace MomentumDiscordBot.Commands.General
 {
+    [RequireUserTrustedRole]
     public class GeneralModule : MomentumModuleBase
     {
         public Configuration Config { get; set; }
+
+        [SlashCommand("say", "executes a custom command")]
+        public async Task ExecCustomCommandAsync(InteractionContext context, [Autocomplete(typeof(AutoCompleteProvider))][Option("option", "name of the custom command")] string name)
+        {
+            CustomCommand command;
+            if (Config.CustomCommands.TryGetValue(name, out command))
+            {
+                var embed = new DiscordEmbedBuilder
+                {
+                    Title = command.Title,
+                    Description = command.Description,
+                    Color = MomentumColor.Blue
+                }.Build();
+                await context.CreateResponseAsync(embed: embed);
+            }
+            else
+            {
+                await ReplyNewEmbedAsync(context, $"Command '{name}' doesn't exist", MomentumColor.Red);
+            }
+        }
     }
 }

--- a/MomentumDiscordBot/Commands/Moderator/ModeratorCustomModule.cs
+++ b/MomentumDiscordBot/Commands/Moderator/ModeratorCustomModule.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.SlashCommands;
+using DSharpPlus.Entities;
+using MomentumDiscordBot.Models;
+using MomentumDiscordBot.Constants;
+using MomentumDiscordBot.Commands.Autocomplete;
+
+namespace MomentumDiscordBot.Commands.Moderator
+{
+    [SlashCommandGroup("custom", "custom commands moderators can add during runtime and print a fixed response with /say")]
+    public class CustomCommandModule : ModeratorModuleBase
+    {
+        public Configuration Config { get; set; }
+
+        [ContextMenu(ApplicationCommandType.MessageContextMenu, "add as custom command")]
+        public async Task MessageMenu(ContextMenuContext context)
+        {
+            DiscordMessage message = context.TargetMessage;
+            string name = "RENAME ME! " + message.Id;
+            string title;
+            string description;
+            if (message.Embeds.Any())
+            {
+                var embed = message.Embeds.First();
+                title = embed.Title;
+                description = embed.Description;
+            }
+            else
+            {
+                title = "";
+                description = message.Content;
+            }
+            DiscordEmbedBuilder embedBuilder;
+            if (Config.CustomCommands.TryAdd(name, new CustomCommand(title, description, context.User.Mention)))
+            {
+                await Config.SaveToFileAsync();
+                embedBuilder = new DiscordEmbedBuilder
+                {
+                    Description = "Command '" + name
+                                    + "' created from message: " + message.JumpLink.ToString()
+                                    + "\nnow rename it with '/custom rename'",
+                    Color = MomentumColor.Blue
+                };
+            }
+            else
+            {
+                embedBuilder = new DiscordEmbedBuilder
+                {
+                    Description = "Failed to add command",
+                    Color = MomentumColor.Red
+                };
+            }
+
+            await context.CreateResponseAsync(embed: embedBuilder.Build(), true);
+        }
+
+        [SlashCommand("add", "creates a new custom commands")]
+        public async Task AddCustomCommandAsync(InteractionContext context, [Option("name", "name of the new command")] string name, [Option("title", "embed title")] string title, [Option("description", "embed description")] string description = null)
+        {
+            if (Config.CustomCommands.ContainsKey(name))
+                await ReplyNewEmbedAsync(context, $"Command '{name}' already exists!", MomentumColor.Red);
+            else if (Config.CustomCommands.TryAdd(name, new CustomCommand(title, description, context.User.Mention)))
+            {
+                await Config.SaveToFileAsync();
+                await ReplyNewEmbedAsync(context, $"Command '{name}' added", MomentumColor.Blue);
+            }
+            else
+                await ReplyNewEmbedAsync(context, "Failed to add command", MomentumColor.Red);
+        }
+
+        [SlashCommand("remove", "deletes a custom commands")]
+        public async Task RemoveCustomCommandAsync(InteractionContext context, [Autocomplete(typeof(AutoCompleteProvider))][Option("name", "name of the custom command")] string name)
+        {
+            if (Config.CustomCommands.TryRemove(name, out _))
+            {
+                await Config.SaveToFileAsync();
+                await ReplyNewEmbedAsync(context, $"Command '{name}' removed", MomentumColor.Blue);
+            }
+            else
+            {
+                await ReplyNewEmbedAsync(context, "Failed to remove command.", MomentumColor.Blue);
+            }
+        }
+
+        [SlashCommand("rename", "deletes a custom commands")]
+        public async Task RenameCustomCommandAsync(InteractionContext context, [Autocomplete(typeof(AutoCompleteProvider))][Option("oldName", "name of the custom command")] string oldName, [Option("newName", "the new name")] string newName)
+        {
+            if (Config.CustomCommands.ContainsKey(newName))
+                await ReplyNewEmbedAsync(context, "Command '" + newName + "' already exists!", MomentumColor.Red);
+
+            else if (Config.CustomCommands.ContainsKey(oldName))
+            {
+                CustomCommand command;
+                if (!Config.CustomCommands.TryGetValue(oldName, out command))
+                    await ReplyNewEmbedAsync(context, "Failed to get old command value.", MomentumColor.Red);
+                else if (!Config.CustomCommands.TryAdd(newName, command))
+                    await ReplyNewEmbedAsync(context, "Failed to add new command.", MomentumColor.Red);
+                else if (!Config.CustomCommands.TryRemove(oldName, out _))
+                    await ReplyNewEmbedAsync(context, "Failed to remove old command.", MomentumColor.Red);
+                else
+                {
+                    await Config.SaveToFileAsync();
+                    await ReplyNewEmbedAsync(context, $"Command '{oldName}' was renamed to '{newName}'", MomentumColor.Blue);
+                }
+            }
+            else
+            {
+                await ReplyNewEmbedAsync(context, $"Command '{oldName}' doesn't exist", MomentumColor.Red);
+            }
+        }
+
+        [SlashCommand("list", "lists all custom commands")]
+        public async Task ListCustomCommandAsync(InteractionContext context, [Option("page", "if there are more than 25 command you can specify which part you want")] long page = 1)
+        {
+            string title = "Info Commands";
+            const int itemsPerPage = 25;
+            int pages = (int)Math.Ceiling((double)Config.CustomCommands.Count() / itemsPerPage);
+            IEnumerable<KeyValuePair<string, CustomCommand>> commands = Config.CustomCommands.OrderByDescending(x => x.Value.CreationTimestamp);
+            if (page < 1)
+                page = 1;
+            else if (page > pages)
+                page = pages;
+            if (pages > 1)
+            {
+                title += $" (Page {page}/{pages})";
+                commands = commands.Skip((int)(itemsPerPage * (page - 1))).Take(itemsPerPage);
+            }
+            var embedBuilder = new DiscordEmbedBuilder
+            {
+                Title = title,
+                Color = MomentumColor.Blue
+            };
+            foreach (var command in commands)
+            {
+                var unixTimestamp = ((DateTimeOffset)command.Value.CreationTimestamp).ToUnixTimeSeconds();
+                embedBuilder.AddField(command.Key, $"added  <t:{unixTimestamp}:R> by {command.Value.User ?? "<unknown>"}");
+            }
+
+            await context.CreateResponseAsync(embed: embedBuilder.Build());
+        }
+    }
+}

--- a/MomentumDiscordBot/Commands/Moderator/ModeratorDiscordEntityModule.cs
+++ b/MomentumDiscordBot/Commands/Moderator/ModeratorDiscordEntityModule.cs
@@ -2,10 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus;
-using DSharpPlus.CommandsNext;
-using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.SlashCommands;
-using DSharpPlus.SlashCommands.Attributes;
 using DSharpPlus.Entities;
 using MomentumDiscordBot.Constants;
 using MomentumDiscordBot.Utilities;

--- a/MomentumDiscordBot/Commands/Moderator/ModeratorModuleBase.cs
+++ b/MomentumDiscordBot/Commands/Moderator/ModeratorModuleBase.cs
@@ -4,5 +4,6 @@ namespace MomentumDiscordBot.Commands.Moderator
 {
     [RequireUserModeratorRole]
     [RequireAdminBotChannel]
+    [ContextMenuRequireUserModeratorRole]
     public class ModeratorModuleBase : MomentumModuleBase { }
 }

--- a/MomentumDiscordBot/Commands/Moderator/ModeratorModuleBase.cs
+++ b/MomentumDiscordBot/Commands/Moderator/ModeratorModuleBase.cs
@@ -5,5 +5,7 @@ namespace MomentumDiscordBot.Commands.Moderator
     [RequireUserModeratorRole]
     [RequireAdminBotChannel]
     [ContextMenuRequireUserModeratorRole]
+    // ContextMenus are used /info and /custom and *not* restricted to the bot channel
+    // they are not actually part of the commandgroup and show up seperatly in the integration settings
     public class ModeratorModuleBase : MomentumModuleBase { }
 }

--- a/MomentumDiscordBot/Models/Configuration.cs
+++ b/MomentumDiscordBot/Models/Configuration.cs
@@ -1,16 +1,37 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using MomentumDiscordBot.Constants;
+using System.Collections.Concurrent;
 
 namespace MomentumDiscordBot.Models
 {
+    public class CustomCommand
+    {
+        public CustomCommand(string title, string description, string user)
+        {
+            this.Title = title;
+            this.Description = description;
+            this.User = user;
+            this.CreationTimestamp = DateTime.Now;
+        }
+        [JsonPropertyName("title")] public string Title { get; set; }
+        [JsonPropertyName("description")] public string Description { get; set; }
+        [JsonPropertyName("user")] public string User { get; set; }
+        [JsonPropertyName("creation_timestamp")] public DateTime CreationTimestamp { get; set; }
+    }
     public class Configuration
     {
+        public Configuration()
+        {
+            CustomCommands = new ConcurrentDictionary<string, CustomCommand>();
+        }
         [JsonPropertyName("environment")] public string Environment { get; set; }
         [JsonPropertyName("bot_token")] public string BotToken { get; set; }
+        [JsonPropertyName("guild_id")] public ulong GuildID { get; set; }
 
         [JsonPropertyName("twitch_api_client_id")]
         public string TwitchApiClientId { get; set; }
@@ -37,7 +58,7 @@ namespace MomentumDiscordBot.Models
 
         [JsonPropertyName("stream_update_interval")]
         public int StreamUpdateInterval { get; set; }
-        
+
         [JsonPropertyName("join_log_channel")] public ulong JoinLogChannel { get; set; }
 
         [JsonPropertyName("message_history_channel")]
@@ -78,6 +99,8 @@ namespace MomentumDiscordBot.Models
         [JsonIgnore] public DiscordEmoji FaqRoleEmoji => DiscordEmoji.FromUnicode(FaqRoleEmojiString);
         [JsonIgnore] public DiscordEmoji AltAccountEmoji => DiscordEmoji.FromUnicode(AltAccountEmojiString);
 
+        [JsonPropertyName("custom_commands")]
+        public ConcurrentDictionary<string, CustomCommand> CustomCommands { get; set; }
         public static async Task<Configuration> LoadFromFileAsync()
         {
             if (!File.Exists(PathConstants.ConfigFilePath))
@@ -93,7 +116,7 @@ namespace MomentumDiscordBot.Models
 
         public async Task SaveToFileAsync()
         {
-            await using var fileStream = File.Open(PathConstants.ConfigFilePath, FileMode.Create);
+            await using var fileStream = File.Open(PathConstants.ConfigFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
 
             await JsonSerializer.SerializeAsync(fileStream, this, new JsonSerializerOptions
             {

--- a/MomentumDiscordBot/Utilities/DiscordExtensions.cs
+++ b/MomentumDiscordBot/Utilities/DiscordExtensions.cs
@@ -26,7 +26,7 @@ namespace MomentumDiscordBot.Utilities
         public static bool RequireRole(this DiscordUser user, ulong roleId)
         {
             // Check if this user is a Guild User, which is the only context where roles exist
-            if (!(user is DiscordMember member))
+            if (user is not DiscordMember member)
             {
                 return false;
             }

--- a/MomentumDiscordBot/Utilities/DiscordExtensions.cs
+++ b/MomentumDiscordBot/Utilities/DiscordExtensions.cs
@@ -23,6 +23,17 @@ namespace MomentumDiscordBot.Utilities
         public static bool IsSelf(this DiscordUser user, DiscordClient discordClient)
             => discordClient.CurrentUser.Id == user.Id;
 
+        public static bool RequireRole(this DiscordUser user, ulong roleId)
+        {
+            // Check if this user is a Guild User, which is the only context where roles exist
+            if (!(user is DiscordMember member))
+            {
+                return false;
+            }
+
+            return member.Roles.Any(role => role.Id == roleId);
+        }
+
         public static Permissions GetDangerousPermissions(this Permissions guildPermissions)
             => DangerousGuildPermissions & guildPermissions;
 

--- a/MomentumDiscordBot/Utilities/FailedChecksExtensions.cs
+++ b/MomentumDiscordBot/Utilities/FailedChecksExtensions.cs
@@ -25,6 +25,13 @@ namespace MomentumDiscordBot.Utilities
             return ReasonPrefix + string.Join(Environment.NewLine + ReasonPrefix, reasons);
         }
 
+        public static string ToCleanResponse(this IEnumerable<ContextMenuCheckBaseAttribute> failedChecks)
+        {
+            var reasons = failedChecks.Select(x => x.ToCleanReason());
+
+            return ReasonPrefix + string.Join(Environment.NewLine + ReasonPrefix, reasons);
+        }
+
         private static string ToCleanReason(this CheckBaseAttribute check)
         {
             return check.ToString();
@@ -33,6 +40,15 @@ namespace MomentumDiscordBot.Utilities
         private static string ToCleanReason(this SlashCheckBaseAttribute check)
         {
             if (check is DescriptiveCheckBaseAttribute descriptiveCheck)
+            {
+                return descriptiveCheck.FailureResponse;
+            }
+
+            return check.ToString();
+        }
+        private static string ToCleanReason(this ContextMenuCheckBaseAttribute check)
+        {
+            if (check is ContextMenuDescriptiveCheckBaseAttribute descriptiveCheck)
             {
                 return descriptiveCheck.FailureResponse;
             }


### PR DESCRIPTION
custom commands can be added with "/custom add" or rightclick on a message -> Apps -> add as custom command
commands can be executed with "/say"
/custom, /say and the context menu permissions can be adjusted separately in the server settings
I order for autocompletion to work after changing the list (adding, removing, renaming) I had to call refresh which makes slashcommands not responsive and they tell you "This command is outdated, please try again in a few minutes". I usually just click on a different channel and back and they work again. The other way I found to get to choiceprovider to refresh is to reconnect the bot but this seems even uglier.
Commands are saved to the config file so right now they would only stick around until the image gets rebuilt (haven't tested this)
The permission check on the contextmenu commands didn't work and I fix this here too. Had to add separate attributes because there is no other base type or interface. They also have different exception handling than slashcommands so I have to touch this again after PR 109 gets merged.