### PR TITLE
/custom edit and video embed

### DIFF
--- a/MomentumDiscordBot/Commands/Admin/AdminConfigModule.cs
+++ b/MomentumDiscordBot/Commands/Admin/AdminConfigModule.cs
@@ -55,17 +55,24 @@ namespace MomentumDiscordBot.Commands.Admin
 
                 if (configParameterType == typeof(string))
                 {
-                    setter.Invoke(Config, new[] {value});
+                    setter.Invoke(Config, new[] { value });
                 }
                 else
                 {
-                    var convertedValue = TypeDescriptor.GetConverter(configParameterType).ConvertFromString(value);
+                    try
+                    {
+                        var convertedValue = TypeDescriptor.GetConverter(configParameterType).ConvertFromString(value);
+                        setter.Invoke(Config, new[] { convertedValue });
+                    }
+                    catch (FormatException)
+                    {
 
-                    setter.Invoke(Config, new[] {convertedValue});
-                    await Config.SaveToFileAsync();
+                        await ReplyNewEmbedAsync(context, $"Can't convert '{value}' to '{selectedProperty.PropertyType}", MomentumColor.Red);
+                        return;
+                    }
                 }
 
-
+                await Config.SaveToFileAsync();
                 await ReplyNewEmbedAsync(context, $"Set '{selectedProperty.Name}' to '{value}'", MomentumColor.Blue);
             }
             else

--- a/MomentumDiscordBot/Commands/Autocomplete/CustomCommandAutoCompleteProvider.cs
+++ b/MomentumDiscordBot/Commands/Autocomplete/CustomCommandAutoCompleteProvider.cs
@@ -1,10 +1,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using DSharpPlus.Entities;
-using MomentumDiscordBot.Models;
 using DSharpPlus.SlashCommands;
+using MomentumDiscordBot.Models;
 
 namespace MomentumDiscordBot.Commands.Autocomplete
 {
@@ -27,6 +28,19 @@ namespace MomentumDiscordBot.Commands.Autocomplete
                 }
             }
             return Task.FromResult(choices.Select(command => new DiscordAutoCompleteChoice(command, command)));
+        }
+    }
+
+    public class CustomCommandPropertyChoiceProvider : IChoiceProvider
+    {
+        public Task<IEnumerable<DiscordApplicationCommandOptionChoice>> Provider()
+        {
+            var properties = typeof(CustomCommand).GetProperties();
+            var choices = properties.Where(x => !x.GetCustomAttributes()
+                                    .Any(x => x.GetType() == typeof(HiddenAttribute)))
+                                    .Take(25)
+                                    .Select(property => new DiscordApplicationCommandOptionChoice(property.Name, property.Name));
+            return Task.FromResult(choices);
         }
     }
 }

--- a/MomentumDiscordBot/Commands/General/GeneralModule.cs
+++ b/MomentumDiscordBot/Commands/General/GeneralModule.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.SlashCommands;
 using DSharpPlus.Entities;
 using MomentumDiscordBot.Models;
@@ -13,19 +15,39 @@ namespace MomentumDiscordBot.Commands.General
     {
         public Configuration Config { get; set; }
 
-        [SlashCommand("say", "executes a custom command")]
+        public const string SayCommandName = "say";
+        [SlashCommand(SayCommandName, "executes a custom command")]
         public async Task ExecCustomCommandAsync(InteractionContext context, [Autocomplete(typeof(AutoCompleteProvider))][Option("option", "name of the custom command")] string name)
         {
             CustomCommand command;
             if (Config.CustomCommands.TryGetValue(name, out command))
             {
-                var embed = new DiscordEmbedBuilder
+                if (string.IsNullOrWhiteSpace(command.Title) && string.IsNullOrWhiteSpace(command.Description))
+                {
+                    //discord refuses to send messages without content
+                    command.Title = "<title here!>";
+                }
+                var embedBuilder = new DiscordEmbedBuilder
                 {
                     Title = command.Title,
                     Description = command.Description,
                     Color = MomentumColor.Blue
-                }.Build();
-                await context.CreateResponseAsync(embed: embed);
+                };
+                if (Uri.IsWellFormedUriString(command.ThumbnailUrl, UriKind.Absolute))
+                {
+                    embedBuilder.Thumbnail = new DiscordEmbedBuilder.EmbedThumbnail
+                    {
+                        Url = command.ThumbnailUrl,
+                        Height = 90,
+                        Width = 160
+                    };
+                }
+                var message = new DiscordMessageBuilder()
+                                .AddEmbed(embedBuilder.Build());
+
+                if (Uri.IsWellFormedUriString(command.ButtonUrl, UriKind.Absolute))
+                    message.AddComponents(new DiscordLinkButtonComponent(command.ButtonUrl, command.ButtonLabel ?? "link"));
+                await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder(message));
             }
             else
             {

--- a/MomentumDiscordBot/Commands/Moderator/ModeratorCustomModule.cs
+++ b/MomentumDiscordBot/Commands/Moderator/ModeratorCustomModule.cs
@@ -213,7 +213,7 @@ namespace MomentumDiscordBot.Commands.Moderator
                             var query = System.Web.HttpUtility.ParseQueryString(link.Query);
                             string id = query["v"];
                             if (id is not null)
-                                command.ThumbnailUrl = $"https://img.youtube.com/vi/{id}/0.jpg";
+                                command.ThumbnailUrl = $"https://img.youtube.com/vi/{id}/mqdefault.jpg";
                         }
                     }
 

--- a/MomentumDiscordBot/Models/Configuration.cs
+++ b/MomentumDiscordBot/Models/Configuration.cs
@@ -32,6 +32,8 @@ namespace MomentumDiscordBot.Models
         [JsonPropertyName("button_label")] public string ButtonLabel { get; set; }
         [JsonPropertyName("thumbnail_url")] public string ThumbnailUrl { get; set; }
         [JsonPropertyName("user")] public string User { get; set; }
+
+        [Hidden]
         [JsonPropertyName("creation_timestamp")] public DateTime CreationTimestamp { get; set; }
     }
     public class Configuration

--- a/MomentumDiscordBot/Models/Configuration.cs
+++ b/MomentumDiscordBot/Models/Configuration.cs
@@ -11,15 +11,26 @@ namespace MomentumDiscordBot.Models
 {
     public class CustomCommand
     {
-        public CustomCommand(string title, string description, string user)
+        public CustomCommand()
+        { }
+        public CustomCommand(string title, string description, string user) : this(title, description, null, null, null, user)
+        { }
+
+        public CustomCommand(string title, string description, string buttonUrl, string buttonLabel, string thumbnailUrl, string user)
         {
             this.Title = title;
             this.Description = description;
+            this.ButtonUrl = buttonUrl;
+            this.ButtonLabel = buttonLabel;
+            this.ThumbnailUrl = thumbnailUrl;
             this.User = user;
             this.CreationTimestamp = DateTime.Now;
         }
         [JsonPropertyName("title")] public string Title { get; set; }
         [JsonPropertyName("description")] public string Description { get; set; }
+        [JsonPropertyName("button_url")] public string ButtonUrl { get; set; }
+        [JsonPropertyName("button_label")] public string ButtonLabel { get; set; }
+        [JsonPropertyName("thumbnail_url")] public string ThumbnailUrl { get; set; }
         [JsonPropertyName("user")] public string User { get; set; }
         [JsonPropertyName("creation_timestamp")] public DateTime CreationTimestamp { get; set; }
     }


### PR DESCRIPTION
As discussed with fingerprince "add as custom command" will ignore the video embeds now and I added /custom edit

"add as custom command" will take the embed content if you use it on a bot /say response. So you can basically copy commands (could be usefull if you break something with edit).
The value in "/custom edit" is optional and it will remove the value if left blank.
Ignoring the video embed (or rather, there shouldn't be one in the first place or you get the url in the message twice) means you also have to add the thumbnail.
I'm sure you can break something with bad urls but since this is a moderator command I didn't check too much.
