### PR TITLE
/timestamp

### DIFF
--- a/MomentumDiscordBot/Commands/Autocomplete/TimezoneAutoCompleteProvider.cs
+++ b/MomentumDiscordBot/Commands/Autocomplete/TimezoneAutoCompleteProvider.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+
+namespace MomentumDiscordBot.Commands.Autocomplete
+{
+    public class TimezoneAutoCompleteProvider : IAutocompleteProvider
+    {
+        public Task<IEnumerable<DiscordAutoCompleteChoice>> Provider(AutocompleteContext context)
+        {
+            string search = context.OptionValue.ToString().ToLower();
+            IEnumerable<TimeZoneInfo> choices = TimeZoneInfo.GetSystemTimeZones();
+            if (!string.IsNullOrWhiteSpace(search))
+                choices = choices.Where(x => x.Id.ToLower().Contains(search));
+            return Task.FromResult(choices.Take(25).Select(x => new DiscordAutoCompleteChoice(x.Id, x.Id)));
+        }
+    }
+}


### PR DESCRIPTION
creates discord timestamp
Parses a lot of date and timeformats like "6.12.2022 13:00" and "1pm". It uses the user discord language settings for parsing.
I didn't check if all discord languages work with cultureinfo so this could throw but I didn't see a "tryconvert" or something an didn't want to add a unnecessary try catch.
Timezone autocompletion is only for "locations" but I could add timezone stuff (but I didn't like it because of summertimes)