### PR TITLE
/say as a reply

### DIFF
--- a/MomentumDiscordBot/Commands/Autocomplete/MessageAutoCompleteProvider.cs
+++ b/MomentumDiscordBot/Commands/Autocomplete/MessageAutoCompleteProvider.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+
+namespace MomentumDiscordBot.Commands.Autocomplete
+{
+    public class MessageAutoCompleteProvider : IAutocompleteProvider
+    {
+        public async Task<IEnumerable<DiscordAutoCompleteChoice>> Provider(AutocompleteContext context)
+        {
+            string search = context.OptionValue.ToString();
+            var channelMessages = await context.Channel.GetMessagesAsync();
+            return channelMessages
+                .Where(x => !x.Author.IsBot && x.Author.IsSystem != true && x.Content.Contains(search))
+                .Take(25)
+                .Select(x => new DiscordAutoCompleteChoice(
+                    string.Join("", $"{x.Author.Username}: {x.Content.Replace('\n', ' ')}".Take(100)),
+                    x.Id.ToString()));
+        }
+    }
+}


### PR DESCRIPTION
Add the option to reply to a message with /say
The autocompletion picks the last 100 messages and passes the ID of the message to /say. The ID is a string because I can only use long and not ulong as a slashcommand arguement.
You can manually copy a message ID and past it in "reply" and it replies to older message. I could make it parse message links too ("copy id" is a dev option in discord) but I don't think its necessary.