### PR TITLE
interactivity service

### DIFF
--- a/MomentumDiscordBot/Commands/MomentumModuleBase.cs
+++ b/MomentumDiscordBot/Commands/MomentumModuleBase.cs
@@ -11,7 +11,12 @@ namespace MomentumDiscordBot.Commands
     {
         public ILogger Logger { get; set; }
 
-        protected static async Task ReplyNewEmbedAsync(InteractionContext context, [Option("text", "text")] string text, [Option("color", "color")] DiscordColor color)
+        protected static async Task ReplyNewEmbedAsync(InteractionContext context, string text, DiscordColor color, bool ephemeral = false)
+        {
+            await ReplyNewEmbedAsync(context.Interaction, text, color, ephemeral);
+        }
+
+        protected static async Task ReplyNewEmbedAsync(DiscordInteraction inter, string text, DiscordColor color, bool ephemeral = false)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -19,7 +24,12 @@ namespace MomentumDiscordBot.Commands
                 Color = color
             }.Build();
 
-            await context.CreateResponseAsync(embed: embed);
+            await ReplyNewEmbedAsync(inter, embed, ephemeral);
+        }
+
+        protected static async Task ReplyNewEmbedAsync(DiscordInteraction inter, DiscordEmbed embed, bool ephemeral = false)
+        {
+            await inter.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().AddEmbed(embed: embed).AsEphemeral(ephemeral));
         }
 
         protected static async Task<DiscordMessage> SlashReplyNewEmbedAsync(InteractionContext context, [Option("text", "text")] string text, [Option("color", "color")] DiscordColor color)

--- a/MomentumDiscordBot/MomentumDiscordBot.csproj
+++ b/MomentumDiscordBot/MomentumDiscordBot.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DSharpPlus" Version="4.3.0-nightly-01152" />
     <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0-nightly-01152" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0-nightly-01152" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/MomentumDiscordBot/Services/InteractivityService.cs
+++ b/MomentumDiscordBot/Services/InteractivityService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using DSharpPlus;
+using DSharpPlus.Interactivity;
+using DSharpPlus.Interactivity.Enums;
+using DSharpPlus.Interactivity.Extensions;
+using DSharpPlus.Entities;
+using MomentumDiscordBot.Models;
+
+namespace MomentumDiscordBot.Services
+{
+    [Microservice(MicroserviceType.InjectAndInitialize)]
+    public class InteractivityService
+    {
+        private readonly Configuration _config;
+        private readonly DiscordClient _discordClient;
+        private DiscordChannel _textChannel;
+        public InteractivityService(Configuration config, DiscordClient discordClient, IServiceProvider services)
+        {
+            discordClient.UseInteractivity(new InteractivityConfiguration()
+            {
+                Timeout = TimeSpan.FromSeconds(10),
+                AckPaginationButtons = true,
+                ResponseBehavior = InteractionResponseBehavior.Respond,
+                ResponseMessage = "Sorry, but this wasn't a valid option, or does not belong to you!",
+            });
+
+            _config = config;
+            _discordClient = discordClient;
+        }
+    }
+}


### PR DESCRIPTION
adds textinput popus to custom command "as custom", add and edit

That's basically what I have shown on discord. Try it tell me what you think.
Here are some things I wanted to mention:
- Edit only shows the popup when you edit the description because everything else is short and the textinput thing isn't perfect
- I can add more fields for add and "as custom" if you want I just left it simple for now
- I didn't see any response if a popup was closed so this will hit the timeout
- I didn't find a way to change "something went wrong" error so this either means the command exists or the timeout was reached
- I can send a channel message if there is a timeout but not respond to something so the message can't be ephemeral (I think)
