### PR TITLE
Use SQLite instead of MySQL

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,0 @@
-MYSQL_USER='bot'
-MYSQL_PASSWORD='password'
-MYSQL_ROOT_PASSWORD='password'
-MYSQL_DATABASE='bot_data'

--- a/MomentumDiscordBot/Constants/PathConstants.cs
+++ b/MomentumDiscordBot/Constants/PathConstants.cs
@@ -7,5 +7,8 @@ namespace MomentumDiscordBot.Constants
     {
         private static readonly string ConfigFolderPath = Path.Combine(Environment.CurrentDirectory, "config");
         internal static readonly string ConfigFilePath = Path.Combine(ConfigFolderPath, "config.json");
+        
+        private static readonly string DbFolderPath = Path.Combine(Environment.CurrentDirectory, "data");
+        internal static readonly string DbFilePath = Path.Combine(DbFolderPath, "bot_data.db");
     }
 }

--- a/MomentumDiscordBot/MomentumDiscordBot.csproj
+++ b/MomentumDiscordBot/MomentumDiscordBot.csproj
@@ -10,11 +10,11 @@
     <PackageReference Include="DSharpPlus" Version="4.3.0-nightly-01152" />
     <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0-nightly-01152" />
     <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0-nightly-01152" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />

--- a/MomentumDiscordBot/Services/InteractivityService.cs
+++ b/MomentumDiscordBot/Services/InteractivityService.cs
@@ -13,7 +13,7 @@ namespace MomentumDiscordBot.Services
     {
         private readonly Configuration _config;
         private readonly DiscordClient _discordClient;
-        private DiscordChannel _textChannel;
+
         public InteractivityService(Configuration config, DiscordClient discordClient, IServiceProvider services)
         {
             discordClient.UseInteractivity(new InteractivityConfiguration()

--- a/MomentumDiscordBot/Utilities/DbContextHelper.cs
+++ b/MomentumDiscordBot/Utilities/DbContextHelper.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.IO;
+using Microsoft.EntityFrameworkCore;
+using MomentumDiscordBot.Constants;
 using MomentumDiscordBot.Models;
 using MomentumDiscordBot.Models.Data;
 
@@ -8,6 +10,6 @@ namespace MomentumDiscordBot.Utilities
     {
         public static MomentumDiscordDbContext GetNewDbContext(Configuration config) =>
             new(new DbContextOptionsBuilder<MomentumDiscordDbContext>()
-                .UseMySql(config.MySqlConnectionString, ServerVersion.AutoDetect(config.MySqlConnectionString)).Options);
+                .UseSqlite($"Data Source={PathConstants.DbFilePath}").Options);
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The bot is used to manage and accompany the Discord server:
 ## Dependencies
 
 * [Docker Compose V3.8+](https://docs.docker.com/compose/install/)
+* [SQLite 3](https://www.sqlite.org/)
 
 ## Dev Setup
 
@@ -27,8 +28,7 @@ Then, clone the repo using a CLI.
 1. Navigate to the root folder: `cd discord-bot`
 2. Copy env.TEMPLATE to .env.dev: `cp env.TEMPLATE .env.dev`
 3. In config/, copy config.template.json.TEMPLATE to config.json: `cd config/ && cp config.json.TEMPLATE config.json`
-4. Fill out the config.json file with your test server's settings. Your `mysql_connection_string` should correspond with
-   the MySQL env vars in .env.dev
+4. Initialise the SQLite DB by running `data/setup-db.sh`
 5. Build and run the Docker containers using Docker Compose with `docker-compose up -d`. For testing changes, you'll
    need to rebuild with `docker-compose build`.
 

--- a/config/config.template.json
+++ b/config/config.template.json
@@ -23,7 +23,6 @@
   "faq_role": 0,
   "developer_id": 0,
   "alt_account_emoji": ":leg:",
-  "mysql_connection_string": "server=db;database=bot_data;uid=bot;pwd=password;",
   "media_verified_role": 0,
   "media_blacklisted_role": 0,
   "media_minimum_days": 3,

--- a/data/init.sql
+++ b/data/init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS `bot_data`.`message_count`
+CREATE TABLE IF NOT EXISTS `message_count`
 (
     `UserId`       bigint unsigned    NOT NULL,
     `ChannelId`    bigint unsigned    NOT NULL,

--- a/data/setup-db.sh
+++ b/data/setup-db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sqlite3 -batch bot_data.db < init.sql

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,6 @@
 version: '3.8'
 
 services:
-  db:
-    env_file:
-      - .env.dev
-    volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
   discord-bot:
     build:
       context: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,22 +3,3 @@ version: '3.8'
 services:
   discord-bot:
     image: ghcr.io/momentum-mod/discord-bot/mmod-discord-bot:net-core
-  db:
-    ports:
-      - 3306:3306 # Run unexposed on 3306 so cron backup can access
-  mysql-cron-backup:
-    image: fradelg/mysql-cron-backup
-    depends_on:
-      - db
-    volumes:
-      - ./backup:/backup
-    environment:
-      - MYSQL_HOST=MomentumDiscordBotDB
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASS=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MAX_BACKUPS=5
-      - INIT_BACKUP=1
-      - CRON_TIME=* * 0 * *
-      - GZIP_LEVEL=9
-    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,9 @@
 version: '3.8'
 
 services:
-  db:
-    container_name: MomentumDiscordBotDB
-    image: mysql:8
-    restart: unless-stopped
-    volumes:
-      - bot-data:/var/lib/mysql
-    healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
-      timeout: 5s
-      retries: 10
   discord-bot:
     container_name: MomentumDiscordBot
     restart: always
-    depends_on:
-      db:
-        condition: service_healthy
     volumes:
       - ./config:/app/config
-volumes:
-  bot-data:
+      - ./data:/app/data

--- a/env.TEMPLATE
+++ b/env.TEMPLATE
@@ -1,4 +1,0 @@
-MYSQL_USER='bot'
-MYSQL_PASSWORD='password'
-MYSQL_ROOT_PASSWORD='password'
-MYSQL_DATABASE='bot_data'


### PR DESCRIPTION
Turns out this was a pretty easy change, and the Docker setup simplifies a great deal.

Backups can just be a `sqlite3 .backup` cronjob I'll write on the server once this is merged. 

Closes #134 